### PR TITLE
Changed the requirements for path.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-'distribute >=0.6'
-'numpy >=1.5.0'
-'scipy >=0.10.0'
+distribute >=0.6
+numpy >=1.5.0
+scipy >=0.10.0
 matplotlib
-'path.py >=2.4.1'
+path.py >=2.4.1,<=9.0.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='PyQt-Fit',
                         'numpy >=1.5.0',
                         'scipy >=0.10.0',
                         'matplotlib',
-                        'path.py >=2.4.1'
+                        'path.py >=2.4.1,<=9.0.0'
                         ],
       extras_require={'Cython': ["Cython >=0.17"]
                       },


### PR DESCRIPTION
Thank you for your nice package!
We have seen some incompatibilities with the newest path.py version.
This is why we have added a maximum requirement for path.py.

Maybe one can think of a more advanced technique for installation (e.g. not a requirements file and repeating the requirements in the setup.py file) for the long run.